### PR TITLE
vm_describe might be empty, which triggers a NoMethodError.

### DIFF
--- a/lib/vagrant-veertu/driver/version_5_0.rb
+++ b/lib/vagrant-veertu/driver/version_5_0.rb
@@ -278,9 +278,13 @@ module VagrantPlugins
         def enable_adapters(adapters)
           vm_describe = get_vm_describe(@uuid)
           puts vm_describe
-          network_cards = vm_describe['hardware']["network cards"]
-          if network_cards.is_a?(Hash)
-            network_cards = [network_cards]
+          if vm_describe.empty?
+            network_cards = []
+          else
+            network_cards = vm_describe['hardware']["network cards"]
+            if network_cards.is_a?(Hash)
+              network_cards = [network_cards]
+            end
           end
           if network_cards.nil?
             network_cards = []


### PR DESCRIPTION
==> default: Preparing network interfaces based on configuration...
    default: translation missing: en.vagrant.veertu.network_adapter
{}
==> default: Destroying VM and associated drives...
/Users/snuf/.vagrant.d/gems/2.2.5/gems/vagrant-veertu-0.0.17/lib/vagrant-veertu/driver/version_5_0.rb:281:in `enable_adapters': undefined method `[]' for nil:NilClass (NoMethodError)
    from /Users/snuf/.vagrant.d/gems/2.2.5/gems/vagrant-veertu-0.0.17/lib/vagrant-veertu/action/network.rb:118:in `call'
    from /opt/vagrant/embedded/gems/gems/vagrant-1.9.3/lib/vagrant/action/warden.rb:34:in `call'